### PR TITLE
Remove Underscore.js from required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ UI-Router Extras adds 4 additional features to help you write large modular appl
 - required:
     - "angular": "~1.2.0",
     - "angular-ui-router": "~0.2.10"
-    - "underscore": "latest" // Temporary dependency: See issue #8
 
 ## Install
 1. download the files


### PR DESCRIPTION
Now that #8 is closed, Underscore.js is no longer required.
