### PR TITLE
fix($stickyState): Fix states not exiting when the state parent attribute is used instead of the dotted notation

### DIFF
--- a/src/stickyStateProvider.js
+++ b/src/stickyStateProvider.js
@@ -225,7 +225,6 @@ function $StickyStateProvider($stateProvider) {
         // registry of inactivated states for descendants of the exited state and also exits those descendants.  It then
         // removes the locals and de-registers the state from the inactivated registry.
         stateExiting: function (exiting, exitQueue, onExit) {
-          var substatePrefix = exiting.self.name + "."; // All descendant states will start with this prefix
           var exitingNames = {};
           angular.forEach(exitQueue, function (state) {
             exitingNames[state.self.name] = true;
@@ -233,8 +232,8 @@ function $StickyStateProvider($stateProvider) {
 
           angular.forEach(inactiveStates, function (inactiveExiting, name) {
             // TODO: Might need to run the inactivations in the proper depth-first order?
-            if (!exitingNames[name] && name.indexOf(substatePrefix) === 0) { // inactivated state's name starts with the prefix.
-              if (DEBUG) $log.debug("Exiting " + name + " because it's a substate of " + substatePrefix + " and wasn't found in ", exitingNames);
+            if (!exitingNames[name] && inactiveExiting.includes[exiting.name]) {
+              if (DEBUG) $log.debug("Exiting " + name + " because it's a substate of " + exiting.name + " and wasn't found in ", exitingNames);
               if (inactiveExiting.self.onExit)
                 $injector.invoke(inactiveExiting.self.onExit, inactiveExiting.self, inactiveExiting.locals.globals);
               inactiveExiting.locals = null;


### PR DESCRIPTION
Using the parent attribute instead of the dotted notation breaks exiting the states because StickyStateProvider.stateExiting only expects state names like `parent.child`. This can easily be fixed by using the states `includes` attribute instead.

I've added a test that fails without the fix and passed with it. Please have a look at it. I couldn't use the `pathFrom` helper function as it too only works with the dotted notation.
