### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "angular", "angularjs", "ui-router", "ui-router-extras", "tab", "tabs", "state", "states", "parallel", "sticky", "lazy", "future"
   ],
   "license": "MIT",
-  "main": [ "./release/ct-ui-router-extras.js", "./release/ct-ui-router-extras.min.js" ],
+  "main": "./release/ct-ui-router-extras.js",
   "ignore": [
     "**/.*",
     "pages",


### PR DESCRIPTION
The main property of bower.json should not contain minified files (see: https://github.com/bower/bower.json-spec).

It should also not contain two instances of the same file. Fixed to contain only the main file.
