### PR TITLE
Resolve re-register of state

### DIFF
--- a/src/futureState.js
+++ b/src/futureState.js
@@ -119,7 +119,7 @@ angular.module('ct.ui.router.extras').provider('$futureState',
               // Config loaded.  Asynchronously lazy-load state definition from URL fragment, if mapped.
               lazyLoadState($injector, futureState).then(function lazyLoadedStateCallback(state) {
                 // TODO: Should have a specific resolve value that says 'dont register a state because I already did'
-                if (state && !$state.get(state))
+                if (state && !$state.get(state.name ? state.name : state))
                   $stateProvider.state(state);
                 resyncing = true;
                 $urlRouter.sync();


### PR DESCRIPTION
I the state is already registered and you return ui-route will throw an error. By passing in the name, ui_route can locate the state
