### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,7 +102,6 @@ module.exports = function (grunt) {
       },
       uglify: {
         options: {
-          mangle: false,
           banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
               '<%= grunt.template.today("yyyy-mm-dd") %> */'
         },


### PR DESCRIPTION
Enable mangling of the variable names when uglifying the release build.  Drastically reduce the minified js file size.
