### PR TITLE
include main module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "karma-jasmine": "0.2.0",
     "lodash": "latest"
   },
+  "main": "release/ct-ui-router-extras",
   "files": [ "release" ],
   "repository": "",
   "engines": {


### PR DESCRIPTION
This is needed for [JSPM](http://jspm.io) (and other loaders).

I know we have files in there, but isn't that for when you're trying to streamline downloading?
`main` is more the entry point / name of the module.
