### PR TITLE
Enabling the use of $urlRouterProvider.otherwise

### DIFF
--- a/src/futureState.js
+++ b/src/futureState.js
@@ -85,15 +85,13 @@ angular.module('ct.ui.router.extras').provider('$futureState',
         return $injector.invoke(factory, factory, { futureState: futureState });
       }
 
+      var otherwiseFunc = [ '$log', '$location',
+        function otherwiseFunc($log, $location) {
+          $log.debug("Unable to map " + $location.path());
+        }];
+
       function futureState_otherwise($injector, $location) {
         var resyncing = false;
-        var $log = $injector.get("$log");
-
-        var otherwiseFunc = [ '$state',
-          function otherwiseFunc($state) {
-            $log.debug("Unable to map " + $location.path());
-            $location.url("/");
-          }];
 
         var lazyLoadMissingState =
           ['$rootScope', '$urlRouter', '$state',
@@ -137,6 +135,16 @@ angular.module('ct.ui.router.extras').provider('$futureState',
       }
 
       $urlRouterProvider.otherwise(futureState_otherwise);
+
+      $urlRouterProvider.otherwise = function(rule) {
+        if (angular.isString(rule)) {
+          var redirect = rule;
+          rule = function () { return redirect; };
+        }
+        else if (!angular.isFunction(rule)) throw new Error("'rule' must be a function");
+        otherwiseFunc = rule;
+        return $urlRouterProvider;
+      }; 
 
       var serviceObject = {
         getResolvePromise: function () {


### PR DESCRIPTION
What about this to fix issues #39 and #71? It would allow to use $urlRouterProvider.otherwise as usual and avoids to silently redirect to "/" when nothing is defined. 
