### PR TITLE
Depend on angular 1.2 <= x < 2.0 rather than 1.2.0 <= x < 1.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,11 +29,11 @@
     "*.iws"
   ],
   "dependencies": {
-    "angular": "~1.2.0",
+    "angular": "~1.2",
     "angular-ui-router": "~0.2.8"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.0",
+    "angular-mocks": "~1.2",
     "lodash": "latest",
     "jquery": "~1.11"
   }


### PR DESCRIPTION
Change bower.json to loosen the requirement on AngularJS versioning.

I'm using this module with AngularJS 1.3 and it's working fine.  It'd be great if you could merge and bump a release so I can use bower/RailsAssets to manage it in my app.
