### PR TITLE
Loosen angular dependency to allow v1.2 and up (including v1.3)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,11 +29,11 @@
     "*.iws"
   ],
   "dependencies": {
-    "angular": "~1.2.0",
+    "angular": "^1.2.0",
     "angular-ui-router": "~0.2.8"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.0",
+    "angular-mocks": "^1.2.0",
     "lodash": "latest",
     "jquery": "~1.11"
   }


### PR DESCRIPTION
This change allows bower to pull in ui-router-extras in an app using angular 1.3 without causing a version conflict in bower.
