### PR TITLE
Provide $inject, $location as annotated parameters to .otherwise()

### DIFF
--- a/src/futureState.js
+++ b/src/futureState.js
@@ -192,7 +192,7 @@ angular.module('ct.ui.router.extras').provider('$futureState',
           rule = function () { return redirect; };
         }
         else if (!angular.isFunction(rule)) throw new Error("'rule' must be a function");
-        otherwiseFunc = rule;
+        otherwiseFunc = ['$injector', '$location', rule];
         return $urlRouterProvider;
       }; 
 


### PR DESCRIPTION
See http://angular-ui.github.io/ui-router/site/#/api/ui.router.router.$urlRouterProvider#methods_otherwise

(I was having issues using the $injector parameter in an otherwise function with `ng-strict-di` enabled.)