### PR TITLE
fix(future): fixed absence of url for real parent of future state

### DIFF
--- a/release/ct-ui-router-extras.js
+++ b/release/ct-ui-router-extras.js
@@ -1227,7 +1227,7 @@ angular.module("ct.ui.router.extras.sticky").config(
       var parentMatcher,  parentName = futureState.name.split(/\./).slice(0, -1).join("."),
         realParent = findState(futureState.parent || parentName);
       if (realParent) {
-        parentMatcher = realParent.url || realParent.navigable.url;
+        parentMatcher = realParent.url || (realParent.navigable && realParent.navigable.url);
       } else if (parentName === "") {
         parentMatcher = $urlMatcherFactory.compile("");
       } else {

--- a/release/modular/ct-ui-router-extras.future.js
+++ b/release/modular/ct-ui-router-extras.future.js
@@ -62,7 +62,7 @@
       var parentMatcher,  parentName = futureState.name.split(/\./).slice(0, -1).join("."),
         realParent = findState(futureState.parent || parentName);
       if (realParent) {
-        parentMatcher = realParent.url || realParent.navigable.url;
+        parentMatcher = realParent.url || (realParent.navigable && realParent.navigable.url);
       } else if (parentName === "") {
         parentMatcher = $urlMatcherFactory.compile("");
       } else {

--- a/src/future.js
+++ b/src/future.js
@@ -52,7 +52,7 @@
       var parentMatcher,  parentName = futureState.name.split(/\./).slice(0, -1).join("."),
         realParent = findState(futureState.parent || parentName);
       if (realParent) {
-        parentMatcher = realParent.url || realParent.navigable.url;
+        parentMatcher = realParent.url || (realParent.navigable && realParent.navigable.url);
       } else if (parentName === "") {
         parentMatcher = $urlMatcherFactory.compile("");
       } else {


### PR DESCRIPTION
If you have an already registered abstract (no url) parent state and you try to register a new future state which is a child of this parent, I found that this fix is needed in order to stop a JS error. The error occurs because it seems that `navigable` is not always set; in these cases it's trying to access the `url` property of a null `navigable` object.