### PR TITLE
feat($deepStateRedirect): Default to ignoreDsr:true when navigating to a parent state

### DIFF
--- a/src/dsr.js
+++ b/src/dsr.js
@@ -59,7 +59,7 @@ angular.module('ct.ui.router.extras.dsr').service("$deepStateRedirect", [ '$root
 
     if (!dsrCfg.fn) {
       dsrCfg.fn = [ '$dsr$', function($dsr$) {
-        return $dsr$.redirect.state != $dsr$.to.state;
+        return $dsr$.redirect.state != $dsr$.to.state && !$dsr$.from.$state.$$state().includes[$dsr$.to.state];
       } ];
     }
     return dsrCfg;
@@ -112,7 +112,11 @@ angular.module('ct.ui.router.extras.dsr').service("$deepStateRedirect", [ '$root
     if (!redirect) return;
 
     // we have a last substate recorded
-    var $dsr$ = { redirect: { state: redirect.state, params: redirect.params}, to: { state: toState.name, params: toParams } };
+    var $dsr$ = {
+      redirect: { state: redirect.state, params: redirect.params },
+      from: { state: fromState.name, params: fromParams, $state: fromState },
+      to: { state: toState.name, params: toParams, $state: toState }
+    };
     var result = $injector.invoke(cfg.fn, toState, { $dsr$: $dsr$ });
     if (!result) return;
     if (result.state) redirect = result;


### PR DESCRIPTION
This lets you forget about specifying `ignoreDsr: true` when navigating to a parent state.

Scenarios that come to mind:
- You're browsing an item's detail and there's a back button that should navigate you back to the list (which is a parent state of the detail).
- You open a modal window that lets you filter the items shown in the list (the modal state is a child of the list state).

In both cases it should be enough to just do `$state.go("^")` instead of `$state.go("^", {}, { ignoreDsr: true })`.