### PR TITLE
Rip out unnecessary parameter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ gulp.task('karma:modules', ['scripts'], function() {
 gulp.task('karma:versions', ['scripts'], function() {
   var karma = require('karma').server;
   var Q = require('q');
-  var versions = [ '0.2.8', '0.2.10', '0.2.12', '0.2.13' ];
+  var versions = [ '0.2.12', '0.2.13' ];
   var dynamicconf = require("./test/conf/karma.dynamic.conf");
 
   var promise = Q(true);

--- a/src/sticky.js
+++ b/src/sticky.js
@@ -317,8 +317,8 @@ angular.module("ct.ui.router.extras.sticky").config(
                     delete ownParams.$$uirouterextrasreload;
                   });
                 } else {
-                  params.push('$$uirouterextrasreload');
-                  ownParams.push('$$uirouterextrasreload');
+                  // params.push('$$uirouterextrasreload');
+                  // ownParams.push('$$uirouterextrasreload');
                   restore.restoreFunctions.push(function() {
                     params.length = params.length -1;
                     ownParams.length = ownParams.length -1;


### PR DESCRIPTION
Removing unnecessary parameter and removing two older versions of UI router that we won't support anymore.