### PR TITLE
Move all module-level variables to the core provider.

### DIFF
--- a/src/future.js
+++ b/src/future.js
@@ -3,7 +3,7 @@
 
   _futureStateProvider.$inject = [ '$stateProvider', '$urlRouterProvider', '$urlMatcherFactoryProvider', 'uirextras_coreProvider' ];
   function _futureStateProvider($stateProvider, $urlRouterProvider, $urlMatcherFactory, uirextras_coreProvider) {
-    var core = uirextras_coreProvider;
+    var core = uirextras_coreProvider.$get();
     var internalStates = core.internalStates;
     var stateFactories = {}, futureStates = {};
     var lazyloadInProgress = false, resolveFunctions = [], initPromise, initDone = false;

--- a/src/stickyProvider.js
+++ b/src/stickyProvider.js
@@ -4,7 +4,7 @@ var mod_sticky = angular.module("ct.ui.router.extras.sticky");
 
 $StickyStateProvider.$inject = [ '$stateProvider', 'uirextras_coreProvider' ];
 function $StickyStateProvider($stateProvider, uirextras_coreProvider) {
-  var core = uirextras_coreProvider;
+    var core = uirextras_coreProvider.$get();
   var inheritParams = core.inheritParams;
   var objectKeys = core.objectKeys;
   var protoKeys = core.protoKeys;
@@ -292,7 +292,7 @@ function $StickyStateProvider($stateProvider, uirextras_coreProvider) {
               if (inactiveExiting.self.onExit)
                 $injector.invoke(inactiveExiting.self.onExit, inactiveExiting.self, inactiveExiting.locals.globals);
               angular.forEach(inactiveExiting.locals, function(localval, key) {
-                delete inactivePseudoState.locals[key];
+                delete core.inactivePseudoState.locals[key];
               });
               inactiveExiting.locals = null;
               inactiveExiting.self.status = 'exited';


### PR DESCRIPTION
Hi Chris,
this should be a fun one for you :) I am developing a state-heavy app in angular, and of course I make heavy use of ui-router and ui-router-extras (thanks a lot for this!).  However, I was missing a "view stack" (like a deck of cards) similar to the Onsen UI navigator.  I hacked up my own version by bootstrapping one angular app for each "card" in the "deck" and only making the top app visible.  This must happen outside angular, because angular apps can't be nested in the DOM tree, but apart from that cosmetic wart things fell into place nicely.  Of course, I have to carefully manage the location to match the active app, but ui-router has all the necessary plunging for that.
What didn't work was ui-router-extra's sticky flag. The errors are difficult to describe: After pushing and popping a "card", the remaining cards got "out of sync" so to speak and lost their stickiness. After banging my head against my code for a while, I found out that ui-router-extra uses module-level state variables a lot. Ouch!  This prevents multiple angular apps using ui-router-extra from running in parallel on a single website.
That's a real shame, because angular is so well modularized.  So I moved the module-level variables to the core provider, and things work out fine for me now.  However, I am ready to admit that I don't get all nuances of the provider initialization, and the way you access the run time instance of a provider in the functions defined in config() (which usually only has access to the provider factory!).  However, a couple of $get invocations seemed to do the trick.  Maybe that's a bit dirty, but not worse than before.
The other problem is that a test fails now:
```
  PhantomJS 1.9.8 (Linux 0.0.0) futureState futureState should lazy load futurestates that have parent futurestates2 FAILED
	Expected '' to be 'hwat'.
	    at /home/marcus/semantics/projects/tablet/angular/ui-router-extras/test/futureSpec.js:141
LOG: 'failed to lazy load state ', 'doesntwork'
LOG: 'failed to lazy load state ', 'doesntwork'
```
I wish I could help you out with that, but frankly, there is an app to write and I don't need the future state feature.  Maybe someone else wants to help clean this up, or maybe it's something easy for you to look at?  Otherwise I might look at it later, but it would be weeks rather than days, so I wanted to get the patch out there right now.  Happy hacking!
BTW, here is a test: [Working](http://plnkr.co/edit/unm9Rkp3PZ6XGDl3VwOA?p=preview) [Broken](http://plnkr.co/edit/WRZeAUNSBk3s7t3iCZDZ?p=preview)
