### PR TITLE
feat(previous): reject $previousState.go if unassigned memo is passed in

### DIFF
--- a/src/previous.js
+++ b/src/previous.js
@@ -1,6 +1,6 @@
 angular.module('ct.ui.router.extras.previous', [ 'ct.ui.router.extras.core', 'ct.ui.router.extras.transition' ]).service("$previousState",
-  [ '$rootScope', '$state',
-    function ($rootScope, $state) {
+  [ '$rootScope', '$state', '$q',
+    function ($rootScope, $state, $q) {
       var previous = null, lastPrevious = null, memos = {};
 
       $rootScope.$on("$transitionStart", function(evt, $transition$) {
@@ -24,6 +24,9 @@ angular.module('ct.ui.router.extras.previous', [ 'ct.ui.router.extras.core', 'ct
         },
         go: function (memoName, options) {
           var to = $previousState.get(memoName);
+          if (memoName && !to) {
+            return $q.reject(new Error('undefined memo'));
+          }
           return $state.go(to.state, to.params, options);
         },
         memo: function (memoName, defaultStateName, defaultStateParams) {

--- a/test/previousSpec.js
+++ b/test/previousSpec.js
@@ -77,6 +77,16 @@ describe("$previousState", function () {
       $q.flush();
       expect($state.current.name === "tabs.tabs2");
     });
+
+    it("should return a rejected promise if memo is undefined", function (done) {
+      testGo("top.people.managerlist", { entered: pathFrom('top', 'top.people.managerlist') });
+      testGo("top.inv.storelist", { entered: pathFrom('top.inv', 'top.inv.storelist'), exited: pathFrom('top.people.managerlist', 'top.people') });
+      $previousState.go('undefined_memo').catch(function (err) {
+        expect(err.message).toBe('undefined memo');
+        done();
+      });
+      $q.flush();
+    });
   });
 
   describe('.get()', function() {


### PR DESCRIPTION
Currently, if I call `$previousState.go(memoName);` with an unassigned memo, it will throw an error saying `TypeError: Cannot read property 'state' of undefined`. Since this function returns `$state.go` which is a promise, I think expected behavior is to return a rejected promise if the `go` was unsuccessful, very similar to how `$state` handles it.

Currently:

```js
$previousState.go('memo') // throws error on unsuccessful state transition
.then(function () {
  // successful state transition
});
```

Expected behavior:

```js
$previousState.go('memo')
.then(function () {
  // successful state transition
})
.catch(function () {
  // unsuccessful state transition
});
```