### PR TITLE
fix(dsr): Fixes error when manually getting redirect for non-dsr states

### DIFF
--- a/src/dsr.js
+++ b/src/dsr.js
@@ -142,8 +142,8 @@ angular.module('ct.ui.router.extras.dsr').service("$deepStateRedirect", [ '$root
       computeDeepStateStatus(state)
       var cfg = getConfig(state);
       var key = getParamsString(params, cfg.params);
-      var redirect = lastSubstate[state.name][key] || cfg['default'];
-      return redirect;
+      var redirect = lastSubstate[state.name];
+      return redirect ? redirect[key] || cfg['default'];
     },
     reset: function(stateOrName, params) {
       if (!stateOrName) {

--- a/src/dsr.js
+++ b/src/dsr.js
@@ -143,7 +143,7 @@ angular.module('ct.ui.router.extras.dsr').service("$deepStateRedirect", [ '$root
       var cfg = getConfig(state);
       var key = getParamsString(params, cfg.params);
       var redirect = lastSubstate[state.name];
-      return redirect ? redirect[key] || cfg['default'];
+      return redirect ? redirect[key] : cfg['default'];
     },
     reset: function(stateOrName, params) {
       if (!stateOrName) {


### PR DESCRIPTION
This is currently throwing a TypeError when passing a state name that has not been marked with `dsr: true`. In actuality we can simply returned `undefined` here (as the name of the function `getRedirect` might imply) as no redirect is defined for such states.