### PR TITLE
fix(dsr): Fixes error when manually getting redirect for non-dsr states

### DIFF
--- a/src/dsr.js
+++ b/src/dsr.js
@@ -142,7 +142,12 @@ angular.module('ct.ui.router.extras.dsr').service("$deepStateRedirect", [ '$root
       computeDeepStateStatus(state)
       var cfg = getConfig(state);
       var key = getParamsString(params, cfg.params);
-      var redirect = lastSubstate[state.name][key] || cfg['default'];
+      var redirect = lastSubstate[state.name];
+      if (redirect && redirect[key]) {
+        redirect = redirect[key];
+      } else {
+        redirect = cfg['default'];
+      }
       return redirect;
     },
     reset: function(stateOrName, params) {


### PR DESCRIPTION
Remake of #306.

This is currently throwing a TypeError when passing a state name that has not been marked with `dsr: true`. In actuality we can simply returned `undefined` here (as the name of the function `getRedirect` might imply) as no redirect is defined for such states.