### PR TITLE
dont reject silent errors

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -466,14 +466,16 @@ angular.module("ct.ui.router.extras.sticky").config(
             return state;
           }, function transitionFailed(err) {
             restore();
-            if (DEBUG &&
-              err.message !== "transition prevented" &&
+            if (err.message !== "transition prevented" &&
               err.message !== "transition aborted" &&
               err.message !== "transition superseded") {
-              $log.debug("transition failed", err);
-              $log.debug(err.stack);
+              if (DEBUG) {
+                  $log.debug("transition failed", err);
+                  $log.debug(err.stack);
+              } else {
+                  return $q.reject(err);
+              }
             }
-            return $q.reject(err);
           });
         };
         return $state;


### PR DESCRIPTION
I'm not entirely sure that this is the correct solution but I saw that in https://github.com/angular-ui/ui-router/commit/66ab048 the transition errors are caught silently and thought that the same should happen here to prevent https://github.com/christopherthielen/ui-router-extras/issues/356

Feedback is welcome